### PR TITLE
feat: claim pending messages from other consumers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,19 @@ Unreleased
 
 *
 
+[0.1.1] - 2023-05-12
+************************************************
+
+Added
+=====
+
+* Option to claim messages from other consumers based on idle time.
+
+Changed
+=======
+
+* Setting ``check_backlog`` will read messages that were not read by this consumer group.
+
 [0.1.0] - 2023-05-04
 ************************************************
 

--- a/docs/decisions/0002-redis-streams-based-event-bus.rst
+++ b/docs/decisions/0002-redis-streams-based-event-bus.rst
@@ -1,0 +1,94 @@
+0002 Redis streams based event bus
+##################################
+
+Status
+******
+
+**Approved**
+
+Context
+*******
+
+The draft `OEP-52: Event Bus Architecture`_ explains how the Open edX platform
+would benefit from an event bus, as well as providing some additional decisions
+around the event bus.
+
+The first implementation for event bus was using Kafka. The issue at stake is
+that Kafka is overkill for all but the largest and most complex deployments,
+however the utility of a global event bus is undisputed, and making a more
+universally deployable event bus will encourage code that leverages this
+capability.
+
+.. _`OEP-52: Event Bus Architecture`: https://github.com/openedx/open-edx-proposals/pull/233
+
+Decision
+********
+
+A second implementation of event bus using `Redis Streams`_ as the backend with
+`Walrus`_ as its python client.
+
+.. _`Walrus`: https://walrus.readthedocs.io/en/latest/
+.. _`Redis Streams`: https://redis.io/docs/data-types/streams/
+
+Why Redis stream?
+*****************
+
+A `Redis stream`_ is a data structure that acts like an append-only log. You can
+use streams to record and simultaneously syndicate events in real time.
+
+It allows creating persistent streams which can be subscribed to by consumers.
+It supports consumer groups which can track all messages that are currently
+pending, that is, messages that were delivered to some consumer of the consumer
+group, but are yet to be acknowledged as processed. Thanks to this feature,
+when accessing the message history of a stream, each consumer will only see
+messages that were delivered to it.
+
+An application consuming these events can create a single consumer group
+(this does not affect the main list of events in the stream) for itself. Then
+the replicas/workers of this application can each create a unique consumer in
+the group. Since consumer groups keep track of messages for each consumer, the
+application will `not lose any event`_ even in case it goes down for some time.
+The consumer group will serve the pending events to the consumer when it comes
+back up with the same consumer name.
+
+.. _`not lose any event`: https://github.com/redis/redis-doc/blob/936de39da1098a1053febdb3defa88338b16c25a/docs/data-types/streams-tutorial.md?plain=1#L401
+.. _`Redis stream`: https://redis.io/docs/data-types/streams-tutorial/#introduction
+
+Please note that consumer name will be a required parameter for Redis consumers
+in order to support above mentioned features.
+
+Why Walrus?
+***********
+
+Walrus is a lightweight python utility for Redis and it subclasses and extends
+redis-py client, allowing it to be used as a drop in replacement. The main
+reason for choosing Walrus is its `simple API`_ for working with streams which
+is much better than having to work with `raw redis commands via redis-py`_.
+
+.. _`simple API`: https://walrus.readthedocs.io/en/latest/streams.html
+.. _`raw redis commands via redis-py`: https://redis-py.readthedocs.io/en/stable/examples/redis-stream-example.html
+
+Consequences
+************
+
+Pros:
+
+* As we already have a dependency on redis, no additional infrastructure will
+  be required.
+* Easier local development setup.
+* Can support small-to-medium scale production Open edX installations.
+* Has support for persistent streams.
+* Support consumer groups to keep track of messages consumed by each consumer.
+* Allows replaying events from any point in time.
+
+Cons:
+
+* Support for proper order of execution is limited. It is recommended to run
+  one consumer per consumer group in order to process events in order. Having
+  multiple consumers in a group does not guarantee of order of execution.
+* Does not have anything similar to schema evolution in Kafka.
+
+Rejected Alternatives
+*********************
+
+None

--- a/docs/decisions/0003-limiting-stream-length.rst
+++ b/docs/decisions/0003-limiting-stream-length.rst
@@ -1,4 +1,4 @@
-0002 Limiting stream length
+0003 Limiting stream length
 ###########################
 
 Status

--- a/edx_event_bus_redis/__init__.py
+++ b/edx_event_bus_redis/__init__.py
@@ -5,6 +5,6 @@ Redis Streams implementation for the Open edX event bus.
 from edx_event_bus_redis.internal.consumer import RedisEventConsumer
 from edx_event_bus_redis.internal.producer import create_producer
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 default_app_config = 'edx_event_bus_redis.apps.EdxEventBusRedisConfig'  # pylint: disable=invalid-name

--- a/edx_event_bus_redis/internal/consumer.py
+++ b/edx_event_bus_redis/internal/consumer.py
@@ -93,18 +93,24 @@ class RedisEventConsumer(EventBusConsumer):
         consumer_name: unique name for consumer within a group.
         last_read_msg_id: Start reading msgs from a specific redis msg id.
         check_backlog: flag to process all messages that were not read by this consumer group.
+        claim_msgs_older_than: claim pending msgs from other consumers in the group with idle time older
+        than a specific time (in milliseconds).
+        has_pending_msgs: flag to process pending msgs first.
         db: Walrus object for redis connection.
         full_topic: topic prefixed with environment name.
         consumer: consumer instance.
     """
 
-    def __init__(self, topic, group_id, signal, consumer_name, last_read_msg_id=None, check_backlog=False):
+    def __init__(self, topic, group_id, signal, consumer_name, last_read_msg_id=None, check_backlog=False,
+                 claim_msgs_older_than=None):
         self.topic = topic
         self.group_id = group_id
         self.signal = signal
         self.consumer_name = consumer_name
         self.last_read_msg_id = last_read_msg_id
         self.check_backlog = check_backlog
+        self.has_pending_msgs = True
+        self.claim_msgs_older_than = claim_msgs_older_than
         self.db = self._create_db()
         self.full_topic = get_full_topic(self.topic)
         self.consumer = self._create_consumer(self.db, self.full_topic)
@@ -153,10 +159,13 @@ class RedisEventConsumer(EventBusConsumer):
         Read pending messages, if no messages found set check_backlog to False.
         """
         logger.debug("Consuming pending msgs first.")
+        if self.claim_msgs_older_than is not None:
+            self.consumer.autoclaim(self.consumer_name, min_idle_time=self.claim_msgs_older_than, count=1)
         msg_meta = self.consumer.pending(count=1, consumer=self.consumer_name)
         if not msg_meta:
             logger.debug("No more pending messages.")
-            self.check_backlog = False
+            self.has_pending_msgs = False
+            self.claim_msgs_older_than = None
             return None
         return self.consumer[msg_meta[0]['message_id']]
 
@@ -215,7 +224,7 @@ class RedisEventConsumer(EventBusConsumer):
                 try:
                     # The first time we want to read our pending messages, in case we crashed and are recovering.
                     # Once we consumed our history, we can start getting new messages.
-                    if self.check_backlog:
+                    if self.has_pending_msgs:
                         redis_raw_msg = self._read_pending_msgs()
                     else:
                         # poll for msg

--- a/edx_event_bus_redis/internal/consumer.py
+++ b/edx_event_bus_redis/internal/consumer.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 REDIS_CONSUMERS_ENABLED = SettingToggle('EVENT_BUS_REDIS_CONSUMERS_ENABLED', default=True)
 
 # .. setting_name: EVENT_BUS_REDIS_CONSUMER_POLL_TIMEOUT
-# .. setting_default: 1.0
+# .. setting_default: 1
 # .. setting_description: How long the consumer should wait, in seconds, for the Redis broker
 #   to respond to a poll() call.
 CONSUMER_POLL_TIMEOUT = getattr(settings, 'EVENT_BUS_REDIS_CONSUMER_POLL_TIMEOUT', 1)
@@ -94,7 +94,7 @@ class RedisEventConsumer(EventBusConsumer):
         last_read_msg_id: Start reading msgs from a specific redis msg id.
         check_backlog: flag to process all messages that were not read by this consumer group.
         claim_msgs_older_than: claim pending msgs from other consumers in the group with idle time older
-        than a specific time (in milliseconds).
+            than a specific time (in milliseconds).
         has_pending_msgs: flag to process pending msgs first.
         db: Walrus object for redis connection.
         full_topic: topic prefixed with environment name.
@@ -109,6 +109,7 @@ class RedisEventConsumer(EventBusConsumer):
         self.consumer_name = consumer_name
         self.last_read_msg_id = last_read_msg_id
         self.check_backlog = check_backlog
+        # always process read but pending msgs first for the consumer in the group.
         self.has_pending_msgs = True
         self.claim_msgs_older_than = claim_msgs_older_than
         self.db = self._create_db()
@@ -156,7 +157,7 @@ class RedisEventConsumer(EventBusConsumer):
 
     def _read_pending_msgs(self) -> Optional[tuple]:
         """
-        Read pending messages, if no messages found set check_backlog to False.
+        Read pending messages, if no messages found set has_pending_msgs to False.
         """
         logger.debug("Consuming pending msgs first.")
         if self.claim_msgs_older_than is not None:


### PR DESCRIPTION
**Description:** Adds option to claim pending msgs from other consumers. Also the consumers will always check for its own pending msgs at first.

**JIRA:** `Private-ref`: https://tasks.opencraft.com/browse/BB-7239

**Dependencies:** https://github.com/openedx/event-bus-redis/pull/13 to avoid conflicts.

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** and **Testing instructions:**

* Please execute below commands in virtual environment to avoid messing with your main python installation.
* Install all dependencies using make requirements
* Run make redis-up in current directory.
* Comment ack command in `edx_event_bus_redis/internal/consumer.py:257` and replace with pass like below
```python
                     if redis_raw_msg:
+                        # self.consumer.ack(redis_raw_msg[0])
+                        pass

```
This way the msg is not acknowledged imitating a real world scenario where a consumer fails before acknowledging a msg.
* Run a consumer with consumer name `test_group.c2` first using below command:
```sh
EVENT_BUS_CONSUMER='edx_event_bus_redis.RedisEventConsumer' EVENT_BUS_PRODUCER='edx_event_bus_redis.create_producer' EVENT_BUS_REDIS_CONNECTION_URL='redis://:password@localhost:6379/' EVENT_BUS_TOPIC_PREFIX='dev' python manage.py consume_events --signal org.openedx.content_authoring.xblock.deleted.v1 --topic xblock-deleted --group_id test_group --extra '{"consumer_name": "test_group.c2"}'
```
* Run make produce_test_event in a separate terminal to produce a fake event, the consumer should log this event.
* **Revert the changes that we did before i.e. start acknowledging the msgs**
* Now stop the consumer and run a new consumer with diff name using below command:
```sh
EVENT_BUS_CONSUMER='edx_event_bus_redis.RedisEventConsumer' EVENT_BUS_PRODUCER='edx_event_bus_redis.create_producer' EVENT_BUS_REDIS_CONNECTION_URL='redis://:password@localhost:6379/' EVENT_BUS_TOPIC_PREFIX='dev' python manage.py consume_events --signal org.openedx.content_
authoring.xblock.deleted.v1 --topic xblock-deleted --group_id test_group --extra '{"consumer_name": "test_group.c1", "claim_msgs_older_than": 10}'
```
* It should consume the msgs which the other consumer did not acknowledge.


**Reviewers:**
- [ ] @Cup0fCoffee 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
